### PR TITLE
Remove Rodrigo Paz Pereira entry from seed data

### DIFF
--- a/prisma/seed/bolivia.ts
+++ b/prisma/seed/bolivia.ts
@@ -790,12 +790,4 @@ export const bolivia: LeaderNoId[] = [
 		tookOffice: `8 November 2020`,
 		leftOffice: `8 November 2025`,
 	},
-	{
-		countryId,
-		name: `Rodrigo Paz Pereira`,
-		party: `Christian Democratic Party`,
-		leaning: leanings.CENTER_RIGHT,
-		tookOffice: `8 November 2025`,
-		leftOffice: null,
-	},
-];
+	


### PR DESCRIPTION
Removed entry for Rodrigo Paz Pereira from the Bolivia seed data.